### PR TITLE
Post Model Setup and DB Updated

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,10 @@
+class Post < ApplicationRecord
+  belongs_to :user
+  belongs_to :team, optional: true
+
+  validates :content, presence: true
+
+  def likes_count
+    likes.count
+  end
+end

--- a/db/migrate/20240630152501_create_posts.rb
+++ b/db/migrate/20240630152501_create_posts.rb
@@ -1,0 +1,11 @@
+class CreatePosts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :posts do |t|
+      t.string :title
+      t.text :content
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_29_145050) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_30_152501) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "posts", force: :cascade do |t|
+    t.string "title"
+    t.text "content"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_posts_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -26,4 +35,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_29_145050) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "posts", "users"
 end

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  content: MyText
+  user: one
+
+two:
+  title: MyString
+  content: MyText
+  user: two

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PostTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Created a post model that I envision to be the basis for forum posts, including the original post and subsequent replies to it.

Posts belong to users, however provided an optional association for posts to belong to a team, as in if a user wants to specify that the post relates to a specific team.

Included a validation for content, so that users creating a forum post must be entering text in the content field.

A likes counter has been implemented in the post model too, with a method to define how likes are count, a future likes model will implement this.

Likely to also add further validations and associations in this post model going forward.