### PR TITLE
Discussions (Threads) Setup and Links Added

### DIFF
--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -1,0 +1,6 @@
+class DiscussionsController < ApplicationController
+
+  def index
+    
+  end
+end

--- a/app/helpers/discussions_helper.rb
+++ b/app/helpers/discussions_helper.rb
@@ -1,0 +1,2 @@
+module DiscussionsHelper
+end

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -1,0 +1,4 @@
+class Discussion < ApplicationRecord
+  has_many :posts
+  belongs_to :user
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,6 @@
 class Post < ApplicationRecord
   belongs_to :user
+  belongs_to :discussion
   belongs_to :team, optional: true
 
   validates :content, presence: true

--- a/app/views/discussions/index.html.erb
+++ b/app/views/discussions/index.html.erb
@@ -1,0 +1,1 @@
+<h1>Active Discussions</h1>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,1 +1,11 @@
 <h1>Football Forum 1</h1>
+
+<% if user_signed_in? %>
+ <div> Welcome <%= current_user.email %> </div>
+  <%= button_to "Sign out", destroy_user_session_path, method: :delete %>
+<% else %>
+  <%= button_to "Sign in", new_user_session_path %>
+<% end %>
+
+
+<%= link_to "Active Discussions", discussions_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,8 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   root to: "pages#home"
+
+  resources :discussions do
+    resources :posts
+  end
 end

--- a/db/migrate/20240703184733_create_discussions.rb
+++ b/db/migrate/20240703184733_create_discussions.rb
@@ -1,0 +1,10 @@
+class CreateDiscussions < ActiveRecord::Migration[7.1]
+  def change
+    create_table :discussions do |t|
+      t.string :title
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240703184822_add_discussion_id_to_posts.rb
+++ b/db/migrate/20240703184822_add_discussion_id_to_posts.rb
@@ -1,0 +1,5 @@
+class AddDiscussionIdToPosts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :posts, :discussion_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_02_175005) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_03_184822) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "discussions", force: :cascade do |t|
+    t.string "title"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_discussions_on_user_id"
+  end
 
   create_table "likes", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -53,6 +61,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_02_175005) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "discussion_id"
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
@@ -68,6 +77,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_02_175005) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "discussions", "users"
   add_foreign_key "likes", "posts"
   add_foreign_key "likes", "users"
   add_foreign_key "posts", "users"

--- a/test/controllers/discussions_controller_test.rb
+++ b/test/controllers/discussions_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DiscussionsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/discussions.yml
+++ b/test/fixtures/discussions.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  user: one
+
+two:
+  title: MyString
+  user: two

--- a/test/models/discussion_test.rb
+++ b/test/models/discussion_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DiscussionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Added MVC for discussions, posts belong to a discussion and a discussion can be seen as a thread.

Created a migration file to enhance the association between discussions and posts, therefore a discussion ID is now associated with a post.

The discussions index base view page version appears along with the simplest possible empty index method in the discussions controller in order to be able to render the discussions index page.

Links added to discussions index and Devise sign in page, with an if statement also included in the same view page for if the user is signed in or not will affect how the page appears for them.

The routes have also been updated to include CRUD resources for discussions and nested resources of posts inside discussions.