### PR TITLE
Incorporated "Current" to handle Current User

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+  before_action :set_current_user, if: :user_signed_in?
+
+  private
+
+  def set_current_user
+    Current.user = current_user
+  end
 end

--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -4,4 +4,20 @@ class DiscussionsController < ApplicationController
   def index
     @discussions = Discussion.all
   end
+
+  def create
+    @discussion = Discussion.new(discussion_params)
+    @discussion.user = Current.user
+
+    if @discussion.save
+      flash[:notice] = "Discussion created successfully!"
+      redirect_to @discussion
+    else
+      render :new
+    end
+  end
+
+  def new
+
+  end
 end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,3 @@
+class Current < ActiveSupport::CurrentAttributes
+  attribute :user
+end

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -1,4 +1,4 @@
 class Discussion < ApplicationRecord
   has_many :posts
-  belongs_to :user
+  belongs_to :user, default: -> { Current.user }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_many :discussions, dependent: :destroy
 end

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -3,8 +3,7 @@
     <a class="navbar-brand">Football Forum 1</a>
     <ul class="navbar-nav mb-4 mb-lg-0">
       <% if user_signed_in? %>
-      <div> Welcome <%= current_user.email %> </div>
-        <%= link_to "Edit User Profile", edit_user_registration_path, method: :edit %>
+        <%= link_to Current.user.email, edit_user_registration_path, method: :edit %>
         <%= link_to "Sign out", destroy_user_session_path, method: :delete %>
       <% else %>
         <%= link_to "Login", new_user_session_path %>


### PR DESCRIPTION
To take advantage of Devise's current user method, a new "current" model has been created with a user attribute to allow current user to be called elsewhere in the application to access the current user. It has also been added to the application controller and discussion model, and has been verified via the console.

Within the discussions controller current user has been called in the new create method (along with other parts including a discussion save and a setup for the discussion creation being dependent upon the discussion params) and an empty new method for handling if the discussion create process is not succesful for whichever reason for the user.

Also added a new current suer email method to the navbar and removed the welcome message so that the edit user path only shows instance of the current user's email address and which when clicked allows the user to edit their user account.