### PR TITLE
Discussion Now able to be Created

### DIFF
--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -9,15 +9,22 @@ class DiscussionsController < ApplicationController
     @discussion = Discussion.new(discussion_params)
     @discussion.user = Current.user
 
-    if @discussion.save
-      flash[:notice] = "Discussion created successfully!"
-      redirect_to @discussion
-    else
-      render :new
+    respond_to do |format|
+      if @discussion.save
+        format.html { redirect_to discussions_path, notice: "A Discussion has been created" }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+      end
     end
   end
 
   def new
     @discussion = Discussion.new
+  end
+
+  private
+
+  def discussion_params
+    params.require(:discussion).permit(:title)
   end
 end

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -1,4 +1,6 @@
 class Discussion < ApplicationRecord
   has_many :posts
   belongs_to :user, default: -> { Current.user }
+
+  validates :title, presence: true
 end

--- a/app/views/discussions/_form.html.erb
+++ b/app/views/discussions/_form.html.erb
@@ -1,0 +1,4 @@
+<%= simple_form_for @discussion do |f| %>
+  <%= f.input :title, label: 'Please enter a discussion title', error: 'Title is mandatory, please specify one' %>
+  <%= f.button :submit %>
+<% end %>

--- a/app/views/discussions/index.html.erb
+++ b/app/views/discussions/index.html.erb
@@ -1,6 +1,6 @@
 <div class="d-flex align-items-center">
   <h1>Active Discussions</h1>
-  <%= link_to "New Discussion", new_discussion_path, class: "btn" %>
+  <%= link_to "New Discussion", new_discussion_path, class: "btn btn-secondary" %>
 </div>
 
 


### PR DESCRIPTION
Within a Simple Form structure, logged in users are now able to create a discussion just with entering a title and submitting it at this stage.

Altered the index page to have a button correctly
appear.

Added to the discussions controller and discussion model to handle title validation and error messages if a title is not entered when creating a discussion. Also added a private discussions controller method to facilitate what params need to be called upon for a discussion.