### PR TITLE
Edit Discussions Setup

### DIFF
--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -1,5 +1,6 @@
 class DiscussionsController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_discussion, only: [:edit, :update]
 
   def index
     @discussions = Discussion.all
@@ -22,9 +23,27 @@ class DiscussionsController < ApplicationController
     @discussion = Discussion.new
   end
 
+  def edit
+
+  end
+
+  def update
+    respond_to do |format|
+      if @discussion.update(discussion_params)
+        format.html { redirect_to discussions_path, notice: "This discussion has been updated." }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+      end
+    end
+  end
+
   private
 
   def discussion_params
     params.require(:discussion).permit(:title)
+  end
+
+  def set_discussion
+    @discussion = Discussion.find(params[:id])
   end
 end

--- a/app/views/discussions/_discussion.html.erb
+++ b/app/views/discussions/_discussion.html.erb
@@ -1,3 +1,7 @@
 <div>
   <%= discussion.title %>
 </div>
+
+<div>
+  <%= link_to "Edit", edit_discussion_path(discussion) %>
+</div>

--- a/app/views/discussions/edit.html.erb
+++ b/app/views/discussions/edit.html.erb
@@ -1,0 +1,3 @@
+<h2> Edit this Discussion</h2>
+
+<%= render("form", discussion: :@discussion) %>


### PR DESCRIPTION
Implemented the ability to edit an existing discussion.

Added edit and update discussions_controller actions to handle the edit and update occurring, while a private controller method also sets the discussion and as per the new before_action is only called when editing and updating a discussion.

A link to edit a discussion exists now within the discussion partial also.

New edit view introduced too for rendering the edit function in the frontend of the application.