### PR TITLE
Delete Discussions Implemented

### DIFF
--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -1,6 +1,6 @@
 class DiscussionsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_discussion, only: [:edit, :update]
+  before_action :set_discussion, only: [:edit, :destroy, :update]
 
   def index
     @discussions = Discussion.all
@@ -35,6 +35,15 @@ class DiscussionsController < ApplicationController
         format.html { render :edit, status: :unprocessable_entity }
       end
     end
+  end
+
+  def show
+    @discussion = Discussion.find(params[:id])
+  end
+
+  def destroy
+    @discussion.destroy!
+    redirect_to discussions_path, notice: "This discussion has now been removed"
   end
 
   private

--- a/app/views/discussions/_discussion.html.erb
+++ b/app/views/discussions/_discussion.html.erb
@@ -1,7 +1,7 @@
-<div>
+<div id="<%= dom_id(discussion) %>" class="mb-4">
   <%= discussion.title %>
-</div>
-
-<div>
-  <%= link_to "Edit", edit_discussion_path(discussion) %>
+  <div>
+    <%= link_to "Edit", edit_discussion_path(discussion) %>
+    <%= link_to "Delete", discussion_path(discussion), data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to delete this discussion? This cannot be undone" } %>
+  </div>
 </div>

--- a/app/views/discussions/show.html.erb
+++ b/app/views/discussions/show.html.erb
@@ -1,0 +1,1 @@
+<h1><%= @discussion.title %></h1>


### PR DESCRIPTION
The first Turbo implementation in the application, to delete a discussion has been created.

When a discussion link_to delete is pressed, it deletes via turbo intercepting the click and issuing a DELETE request to the server.

A delete method in the controller has been setup for handling delete discussion requests, along with a basic discussion show page for displaying active discussions.