### PR TITLE
Show Discussions Setup With Turbo also Enhancing the App

### DIFF
--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -1,6 +1,6 @@
 class DiscussionsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_discussion, only: [:edit, :destroy, :update]
+  before_action :set_discussion, only: [:show, :edit, :destroy, :update]
 
   def index
     @discussions = Discussion.all
@@ -12,7 +12,7 @@ class DiscussionsController < ApplicationController
 
     respond_to do |format|
       if @discussion.save
-        format.html { redirect_to discussions_path, notice: "A Discussion has been created" }
+        format.html { redirect_to @discussion, notice: "A Discussion has been created" }
       else
         format.html { render :new, status: :unprocessable_entity }
       end
@@ -30,7 +30,7 @@ class DiscussionsController < ApplicationController
   def update
     respond_to do |format|
       if @discussion.update(discussion_params)
-        format.html { redirect_to discussions_path, notice: "This discussion has been updated." }
+        format.html { redirect_to @discussion, notice: "This discussion has been updated." }
       else
         format.html { render :edit, status: :unprocessable_entity }
       end

--- a/app/views/discussions/_discussion.html.erb
+++ b/app/views/discussions/_discussion.html.erb
@@ -1,5 +1,5 @@
 <div id="<%= dom_id(discussion) %>" class="mb-4">
-  <%= discussion.title %>
+  <h3><%= link_to discussion.title, discussion %></h3>
   <div>
     <%= link_to "Edit", edit_discussion_path(discussion) %>
     <%= link_to "Delete", discussion_path(discussion), data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to delete this discussion? This cannot be undone" } %>

--- a/app/views/discussions/_discussion_header.html.erb
+++ b/app/views/discussions/_discussion_header.html.erb
@@ -1,0 +1,11 @@
+<%= turbo_frame_tag dom_id(discussion) do %>
+  <div class="d-flex align-tems-center">
+    <div>
+      <h2><%= @discussion.title %></h2>
+    </div>
+    <div>
+      <%= link_to "Edit", edit_discussion_path(@discussion) %>
+      <%= link_to "Delete", discussion_path(@discussion), data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to delete this discussion? This cannot be undone" } %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/discussions/edit.html.erb
+++ b/app/views/discussions/edit.html.erb
@@ -1,3 +1,5 @@
 <h2> Edit this Discussion</h2>
-
-<%= render("form", discussion: :@discussion) %>
+<%= turbo_frame_tag dom_id(@discussion) do %>
+  <%= render("form", discussion: :@discussion) %>
+  <%= link_to "Cancel", @discussion %>
+<% end %>

--- a/app/views/discussions/show.html.erb
+++ b/app/views/discussions/show.html.erb
@@ -1,1 +1,1 @@
-<h1><%= @discussion.title %></h1>
+<%= render(partial: "discussions/discussion_header", locals: { discussion: @discussion }) %>


### PR DESCRIPTION
Created a new partial for handling the discussion content being shown, therefore in a show, edit or delete view for a discussion the user will be able to view the discussion during each action.

Updated the edit and update actions in the discussions controller to handle redirects better.

The edit page has been updated to allow to cancel via a link which redirects the user to the specific discussion.

Several Turbo Frame Tags now encapsulate the new show and existing edit pages for discussions.

Furthermore, a link to the discussion has been added to the discussion partial to link to the specified discussion page.