### PR TITLE
to_param added to the discussion model

### DIFF
--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -3,4 +3,8 @@ class Discussion < ApplicationRecord
   belongs_to :user, default: -> { Current.user }
 
   validates :title, presence: true
+
+  def to_param
+    "#{id}-#{title.downcase.to_s[0...100]}".parameterize
+  end
 end


### PR DESCRIPTION
In order to move away from a football discussion just being a numbered record in the URL, a to_param method has been set in the discussion model to take the discussion name, enforce parameters on it to separate words via hyphens and limit the URL title character count to 100 characters so that the URL does not grow to be too long.