### PR TITLE
Post Added to New Discussions

### DIFF
--- a/app/assets/stylesheets/actiontext.scss
+++ b/app/assets/stylesheets/actiontext.scss
@@ -1,4 +1,4 @@
-@import "trix/dist/trix";
+@import "trix";
 
 /*
  * We need to override trix.css’s image gallery styles to accommodate the

--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -21,6 +21,7 @@ class DiscussionsController < ApplicationController
 
   def new
     @discussion = Discussion.new
+    @discussion.posts.new
   end
 
   def edit
@@ -50,7 +51,7 @@ class DiscussionsController < ApplicationController
   private
 
   def discussion_params
-    params.require(:discussion).permit(:title)
+    params.require(:discussion).permit(:title, posts_attributes: :content)
   end
 
   def set_discussion

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -6,6 +6,8 @@ class Discussion < ApplicationRecord
 
   has_many :posts, dependent: :destroy
 
+  accepts_nested_attributes_for :posts
+
   after_create_commit -> { broadcast_prepend_to "discussions" }
   after_update_commit -> { broadcast_replace_to "discussions" }
   after_destroy_commit -> { broadcast_remove_to "discussions" }

--- a/app/views/discussions/_form.html.erb
+++ b/app/views/discussions/_form.html.erb
@@ -1,4 +1,13 @@
 <%= simple_form_for @discussion do |f| %>
   <%= f.input :title, label: 'Please enter a discussion title', error: 'Title is mandatory, please specify one' %>
+
+  <% if @discussion.new_record? %>
+    <%= f.simple_fields_for :posts do |p| %>
+      <div class="mb-3">
+        <%= p.rich_text_area :content, placeholder: "Talk football..." %>
+      </div>
+    <% end %>
+  <% end %>
+
   <%= f.button :submit %>
 <% end %>


### PR DESCRIPTION
Users are now required to add an initial post to the discussion when creating it.

The post nested within a new discussion has been added to the discussion model and rendered inside a Trix rich text editor box in the discussion form partial. Also added the post attribute to the discussions controller params private method to call specific post params in discussions, such as in this instance "content".

Also fixed an error with how the Trix was being imported.