### PR TITLE
Posts can now be created within discussions

### DIFF
--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -41,6 +41,7 @@ class DiscussionsController < ApplicationController
 
   def show
     @discussion = Discussion.find(params[:id])
+    @new_post = @discussion.posts.new
   end
 
   def destroy

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,0 +1,29 @@
+module Discussions
+  class PostsController < ApplicationController
+    before_action :authenticate_user!
+    before_action :set_discussion
+
+    def create
+      @post = @discussion.posts.new(post_params)
+
+      respond_to do |format|
+        if @post.save
+          format.html { redirect_to discussion_path(@discussion), notice: "Post created" }
+        else
+          format.turbo_stream
+          format.html { render :new, status: :unprocessable_entity }
+        end
+      end
+    end
+
+    private
+
+    def set_discussion
+      @discussion = Discussion.find(params[:discussion_id])
+    end
+
+    def post_params
+      params.require(:post).permit(:content)
+    end
+  end
+end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,0 +1,2 @@
+module PostsHelper
+end

--- a/app/views/discussions/posts/_form.html.erb
+++ b/app/views/discussions/posts/_form.html.erb
@@ -1,0 +1,9 @@
+<%= turbo_frame_tag "#{dom_id(post)}_form", target: "_top" do %>
+  <%= simple_form_for([post.discussion, post]) do |f| %>
+    <%= f.error_notification %>
+
+    <%= f.input :content, as: :rich_text_area, input_html: { placeholder: "Add your comment", autofocus: true }, label: false %>
+
+    <%= f.button :submit, class: "btn btn-primary" %>
+  <% end %>
+<% end %>

--- a/app/views/discussions/posts/create.turbo_stream.erb
+++ b/app/views/discussions/posts/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "new_post_form" do %>
+  <%= render partial: "discussions/posts/form", formats: :html, locals: { post: @post } %>
+<% end %>

--- a/app/views/discussions/show.html.erb
+++ b/app/views/discussions/show.html.erb
@@ -1,3 +1,9 @@
 <%= turbo_stream_from @discussion %>
 
 <%= render(partial: "discussions/discussion_header", locals: { discussion: @discussion }) %>
+
+<hr class="my-2">
+
+<div id="<%= dom_id(@new_post) %>">
+  <%= render("discussions/posts/form", post: @new_post) %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   root to: "pages#home"
 
   resources :discussions do
-    resources :posts
+    resources :posts, only: [:create], module: :discussions
   end
 
   mount MissionControl::Jobs::Engine, at: "/jobs"

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PostsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Posts now have a partial form for them and can be created in response to a discussion. 

A new Turbo Stream in the same new posts views folder inside the discussions folder allows quick submitting of posts to the specific discussion.

The routes have been configured more precisely to attach posts to discussions via a module on top of the already established nesting inside the discussions routes.