### PR TITLE
Posts Show and Layout Adjustments Made

### DIFF
--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -40,7 +40,7 @@ class DiscussionsController < ApplicationController
   end
 
   def show
-    @discussion = Discussion.find(params[:id])
+    @posts = @discussion.posts.all.order(created_at: :asc)
     @new_post = @discussion.posts.new
   end
 

--- a/app/views/discussions/_discussion_header.html.erb
+++ b/app/views/discussions/_discussion_header.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag dom_id(discussion) do %>
-  <div class="d-flex align-tems-center">
+  <div class="d-flex align-items-center">
     <div>
       <h2><%= discussion.title %></h2>
     </div>

--- a/app/views/discussions/index.html.erb
+++ b/app/views/discussions/index.html.erb
@@ -1,8 +1,8 @@
 <%= turbo_stream_from 'discussions' %>
 
-<div class="d-flex align-items-center">
+<div class="d-flex justify-content-between">
   <h1>Active Discussions</h1>
-  <%= link_to "New Discussion", new_discussion_path, class: "btn btn-secondary" %>
+  <%= link_to "Create a Discussion", new_discussion_path, class: "btn btn-secondary" %>
 </div>
 
 

--- a/app/views/discussions/posts/_post.html.erb
+++ b/app/views/discussions/posts/_post.html.erb
@@ -1,0 +1,5 @@
+<div class="card my-2">
+  <div class="card-body">
+    <%= render(partial: "discussions/posts/posts_header", locals: { post: post }) %>
+    <%= post.content %>
+</div>

--- a/app/views/discussions/posts/_posts_header.html.erb
+++ b/app/views/discussions/posts/_posts_header.html.erb
@@ -1,0 +1,2 @@
+<h2 class="card-title"><%= post.user %></h2>
+<h4 class="card-subtitle mb-2 text-muted border-bottom pb-2">Posted on: <%= post.created_at %></h4>

--- a/app/views/discussions/show.html.erb
+++ b/app/views/discussions/show.html.erb
@@ -2,8 +2,14 @@
 
 <%= render(partial: "discussions/discussion_header", locals: { discussion: @discussion }) %>
 
-<hr class="my-2">
+<div class="mt-4">
+  <%= render partial: "discussions/posts/post", collection: @posts %>
+</div>
+
+<hr class="my-4">
 
 <div id="<%= dom_id(@new_post) %>">
   <%= render("discussions/posts/form", post: @new_post) %>
 </div>
+
+<%= link_to "Back to Discussions", discussions_path, class: "btn btn-secondary" %>


### PR DESCRIPTION
Posts are now visible in the discussion page they
were created in via a new page partial.

Posts are timestamped as to when they were made in the newly created posts header partial that is called in the discussions show page and subsequently displays there.

The discussions index have had the top of the layout altered, a button now contains the newly revised worded "Create a Discussion" button link, and it appears opposite the Active Discussions title on the page.

The discussions controller has also been updated in the show method to show posts in ascending created at order. While the discussion find params in the same method have been removed as not currently needed.

Also added a Back to Discussions button to allow the user to return to the discussions index.