### PR TITLE
Posts now Edited and Created Update in all places in realtime

### DIFF
--- a/app/controllers/discussions/posts_controller.rb
+++ b/app/controllers/discussions/posts_controller.rb
@@ -2,7 +2,27 @@ module Discussions
   class PostsController < ApplicationController
     before_action :authenticate_user!
     before_action :set_discussion
+    before_action :set_post, only: [:show, :edit, :update]
 
+
+    def show
+
+    end
+
+    def edit
+
+    end
+
+
+    def update
+      respond_to do |format|
+        if @post.update(post_params)
+          format.html { redirect_to @post.discussion, notice: "Post updated" }
+        else
+          format.html { render :edit, status: :unprocessable_entity }
+        end
+      end
+    end
     def create
       @post = @discussion.posts.new(post_params)
 
@@ -21,6 +41,11 @@ module Discussions
     def set_discussion
       @discussion = Discussion.find(params[:discussion_id])
     end
+
+    def set_post
+      @post = @discussion.posts.find(params[:id])
+    end
+
 
     def post_params
       params.require(:post).permit(:content)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -8,7 +8,8 @@ class Post < ApplicationRecord
   validates :content, presence: true
 
   after_create_commit -> { broadcast_append_to discussion, partial: "discussions/posts/post", locals: { post: self }}
-  
+  after_update_commit -> { broadcast_replace_to discussion, partial: "discussions/posts/post", locals: { post: self }}
+
 
   def likes_count
     likes.count

--- a/app/views/discussions/index.html.erb
+++ b/app/views/discussions/index.html.erb
@@ -1,12 +1,12 @@
 <%= turbo_stream_from 'discussions' %>
 
-<div class="d-flex justify-content-between  align-items-center">
+<div class="d-flex justify-content-between align-items-center">
   <h1>Active Discussions</h1>
   <%= link_to "Create a Discussion", new_discussion_path, class: "btn btn-secondary" %>
 </div>
 
 
-<div class="row mt-2">
+<div class="row mt-4">
   <div class="col">
     <div id="discussions">
       <%= render @discussions %>

--- a/app/views/discussions/posts/_post.html.erb
+++ b/app/views/discussions/posts/_post.html.erb
@@ -1,5 +1,12 @@
-<div class="card my-2">
-  <div class="card-body">
-    <%= render(partial: "discussions/posts/posts_header", locals: { post: post }) %>
-    <%= post.content %>
-</div>
+<%= turbo_frame_tag dom_id(post) do %>
+  <div class="card my-2">
+    <div class="card-body">
+      <%= render(partial: "discussions/posts/posts_header", locals: { post: post }) %>
+      <%= post.content %>
+    </div>
+
+    <div class="card-footer">
+      <%= link_to "Edit", edit_discussion_post_path(post.discussion, post), data: { turbo_frame: dom_id(post) } %>
+    </div>
+  </div>
+<% end%>

--- a/app/views/discussions/posts/edit.html.erb
+++ b/app/views/discussions/posts/edit.html.erb
@@ -1,0 +1,10 @@
+<h1>Edit post</h1>
+<%= turbo_frame_tag dom_id(@post) do %>
+  <div class="card my-4">
+    <div class="card-body">
+      <%= render(partial: "discussions/posts/posts_header", locals: { post: @post }) %>
+      <%= render("form", post: @post) %>
+      <%= link_to 'Back', discussion_post_path(@post.discussion, @post) %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/discussions/posts/show.html.erb
+++ b/app/views/discussions/posts/show.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "discussions/posts/post", locals: { post: @post } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   root to: "pages#home"
 
   resources :discussions do
-    resources :posts, only: [:create], module: :discussions
+    resources :posts, only: [:create, :show, :edit, :update], module: :discussions
   end
 
   mount MissionControl::Jobs::Engine, at: "/jobs"


### PR DESCRIPTION
Incorporated the edit post function, that appears in the same show discussion and post page as posts that are shown and also created. Once edited and edit confirmed by the user they are rendered in their updated format in realtime to the current user and other users on the same page.

Also fixed the show page error where new posts would appear below the create post form rather than the intended position of above the form with already existing posts, they now appear in the correct place with existing posts in the specific discussion.