### PR TITLE
Deleting posts in realtime

### DIFF
--- a/app/controllers/discussions/posts_controller.rb
+++ b/app/controllers/discussions/posts_controller.rb
@@ -2,7 +2,7 @@ module Discussions
   class PostsController < ApplicationController
     before_action :authenticate_user!
     before_action :set_discussion
-    before_action :set_post, only: [:show, :edit, :update]
+    before_action :set_post, only: [:show, :edit, :update, :destroy]
 
 
     def show
@@ -33,6 +33,15 @@ module Discussions
           format.turbo_stream
           format.html { render :new, status: :unprocessable_entity }
         end
+      end
+    end
+
+    def destroy
+      @post.destroy
+
+      respond_to do |format|
+        format.turbo_stream { }
+        format.html { redirect_to @post.discussion, notice: "Post has been deleted" }
       end
     end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -9,6 +9,7 @@ class Post < ApplicationRecord
 
   after_create_commit -> { broadcast_append_to discussion, partial: "discussions/posts/post", locals: { post: self }}
   after_update_commit -> { broadcast_replace_to discussion, partial: "discussions/posts/post", locals: { post: self }}
+  after_destroy_commit -> { broadcast_remove_to discussion }
 
 
   def likes_count

--- a/app/views/discussions/posts/_post.html.erb
+++ b/app/views/discussions/posts/_post.html.erb
@@ -13,5 +13,6 @@
                 turbo_frame: dom_id(post),
                 turbo_confirm: "Are you sure you want to delete this post?"
               } %>    </div>
-      </div>
+      </div>#
+    </div>
 <% end %>

--- a/app/views/discussions/posts/_post.html.erb
+++ b/app/views/discussions/posts/_post.html.erb
@@ -6,7 +6,12 @@
     </div>
 
     <div class="card-footer">
-      <%= link_to "Edit", edit_discussion_post_path(post.discussion, post), data: { turbo_frame: dom_id(post) } %>
-    </div>
-  </div>
-<% end%>
+      <%= link_to "Edit", edit_discussion_post_path(post.discussion, post), data: { turbo_frame: dom_id(post) } %> |
+      <%= link_to "Delete", discussion_post_path(post.discussion, post),
+              data: {
+                turbo_method: :delete,
+                turbo_frame: dom_id(post),
+                turbo_confirm: "Are you sure you want to delete this post?"
+              } %>    </div>
+      </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   root to: "pages#home"
 
   resources :discussions do
-    resources :posts, only: [:create, :show, :edit, :update], module: :discussions
+    resources :posts, only: [:create, :show, :edit, :update, :destroy], module: :discussions
   end
 
   mount MissionControl::Jobs::Engine, at: "/jobs"


### PR DESCRIPTION
 Posts are now Deleted in Real Time

    A prompt now appears when a delete link is clicked by
    the user, once confirmed on the notice prompt the post
    is then deleted in realtime to the user and others
    without a page refresh being necessary.

    A new Turbo frame is inserted in the deletion link data
    along with a Turbo confirmation message.