### PR TITLE
Categories Added to the Forum

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,0 +1,70 @@
+class CategoriesController < ApplicationController
+  before_action :set_category, only: %i[ show edit update destroy ]
+
+  # GET /categories or /categories.json
+  def index
+    @categories = Category.all
+  end
+
+  # GET /categories/1 or /categories/1.json
+  def show
+  end
+
+  # GET /categories/new
+  def new
+    @category = Category.new
+  end
+
+  # GET /categories/1/edit
+  def edit
+  end
+
+  # POST /categories or /categories.json
+  def create
+    @category = Category.new(category_params)
+
+    respond_to do |format|
+      if @category.save
+        format.html { redirect_to category_url(@category), notice: "Category was successfully created." }
+        format.json { render :show, status: :created, location: @category }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @category.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /categories/1 or /categories/1.json
+  def update
+    respond_to do |format|
+      if @category.update(category_params)
+        format.html { redirect_to category_url(@category), notice: "Category was successfully updated." }
+        format.json { render :show, status: :ok, location: @category }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @category.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /categories/1 or /categories/1.json
+  def destroy
+    @category.destroy!
+
+    respond_to do |format|
+      format.html { redirect_to categories_url, notice: "Category was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_category
+      @category = Category.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def category_params
+      params.require(:category).permit(:name, :discussions_count)
+    end
+end

--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -7,6 +7,7 @@ class DiscussionsController < ApplicationController
   end
 
   def show
+    set_discussion
     @posts = @discussion.posts.all.order(created_at: :asc)
     @new_post = @discussion.posts.new
   end
@@ -51,7 +52,7 @@ class DiscussionsController < ApplicationController
   private
 
   def discussion_params
-    params.require(:discussion).permit(:title, posts_attributes: :content)
+    params.require(:discussion).permit(:title, :category_id, posts_attributes: :content)
   end
 
   def set_discussion

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -1,0 +1,2 @@
+module CategoriesHelper
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,5 @@
+class Category < ApplicationRecord
+  has_many :discussions, dependent: :nullify
+
+  scope :sorted, -> { order(name: :asc ) }
+end

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -1,5 +1,6 @@
 class Discussion < ApplicationRecord
   belongs_to :user, default: -> { Current.user }
+  belongs_to :category, counter_cache: true, touch: true
 
   validates :title, presence: true
 

--- a/app/views/categories/_category.html.erb
+++ b/app/views/categories/_category.html.erb
@@ -1,0 +1,12 @@
+<div id="<%= dom_id category %>">
+  <p>
+    <strong>Name:</strong>
+    <%= category.name %>
+  </p>
+
+  <p>
+    <strong>Discussions count:</strong>
+    <%= category.discussions_count %>
+  </p>
+
+</div>

--- a/app/views/categories/_category.json.jbuilder
+++ b/app/views/categories/_category.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! category, :id, :name, :discussions_count, :created_at, :updated_at
+json.url category_url(category, format: :json)

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -1,0 +1,14 @@
+
+<%= simple_form_for(@category) do |f| %>
+  <%= f.error_notification %>
+  <%= f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present? %>
+
+  <div class="form-inputs">
+    <%= f.input :name %>
+    <%= f.input :discussions_count %>
+  </div>
+
+  <div class="form-actions">
+    <%= f.button :submit %>
+  </div>
+<% end %>

--- a/app/views/categories/edit.html.erb
+++ b/app/views/categories/edit.html.erb
@@ -1,0 +1,10 @@
+<h1>Editing category</h1>
+
+<%= render "form", category: @category %>
+
+<br>
+
+<div>
+  <%= link_to "Show this category", @category %> |
+  <%= link_to "Back to categories", categories_path %>
+</div>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,0 +1,14 @@
+<p style="color: green"><%= notice %></p>
+
+<h1>Categories</h1>
+
+<div id="categories">
+  <% @categories.each do |category| %>
+    <%= render category %>
+    <p>
+      <%= link_to "Show this category", category %>
+    </p>
+  <% end %>
+</div>
+
+<%= link_to "New category", new_category_path %>

--- a/app/views/categories/index.json.jbuilder
+++ b/app/views/categories/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @categories, partial: "categories/category", as: :category

--- a/app/views/categories/new.html.erb
+++ b/app/views/categories/new.html.erb
@@ -1,0 +1,9 @@
+<h1>New category</h1>
+
+<%= render "form", category: @category %>
+
+<br>
+
+<div>
+  <%= link_to "Back to categories", categories_path %>
+</div>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,0 +1,10 @@
+<p style="color: green"><%= notice %></p>
+
+<%= render @category %>
+
+<div>
+  <%= link_to "Edit this category", edit_category_path(@category) %> |
+  <%= link_to "Back to categories", categories_path %>
+
+  <%= button_to "Destroy this category", @category, method: :delete %>
+</div>

--- a/app/views/categories/show.json.jbuilder
+++ b/app/views/categories/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "categories/category", category: @category

--- a/app/views/discussions/_form.html.erb
+++ b/app/views/discussions/_form.html.erb
@@ -1,6 +1,12 @@
 <%= simple_form_for @discussion do |f| %>
   <%= f.input :title, label: 'Please enter a discussion title', error: 'Title is mandatory, please specify one' %>
 
+  <div class="mb-2">
+    <%= f.label :category_id, "Choose a category..." %>
+    <%= f.collection_select :category_id, Category.sorted, :id, :name,
+    { include_blank: "Pick a category..."}, { autofocus: false, class: "form-control" } %>
+  </div>
+
   <% if @discussion.new_record? %>
     <%= f.simple_fields_for :posts do |p| %>
       <div class="mb-3">

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -2,6 +2,10 @@
   <div class="container-fluid">
     <a class="navbar-brand">Football Forum 1</a>
     <ul class="navbar-nav mb-4 mb-lg-0">
+      <%= link_to "Discussions", discussions_path, class: "nav-item nav-link" %>
+      <%= link_to "Categories", categories_path, class: "nav-item nav-link" %>
+    </ul>
+    <ul class="navbar-nav mb-2 mb-lg-2">
       <% if user_signed_in? %>
         <%= link_to Current.user.email, edit_user_registration_path, method: :edit %>
         <%= link_to "Sign out", destroy_user_session_path, method: :delete %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :categories
   devise_for :users
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/db/migrate/20240722214833_create_categories.rb
+++ b/db/migrate/20240722214833_create_categories.rb
@@ -1,0 +1,10 @@
+class CreateCategories < ActiveRecord::Migration[7.1]
+  def change
+    create_table :categories do |t|
+      t.string :name
+      t.integer :discussions_count
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240722214917_add_category_id_to_discussion.rb
+++ b/db/migrate/20240722214917_add_category_id_to_discussion.rb
@@ -1,0 +1,5 @@
+class AddCategoryIdToDiscussion < ActiveRecord::Migration[7.1]
+  def change
+    add_column :discussions, :category_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_16_170454) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_22_214917) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -52,12 +52,20 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_16_170454) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "categories", force: :cascade do |t|
+    t.string "name"
+    t.integer "discussions_count"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "discussions", force: :cascade do |t|
     t.string "title"
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "posts_count", default: 0
+    t.bigint "category_id"
     t.index ["user_id"], name: "index_discussions_on_user_id"
   end
 

--- a/test/controllers/categories_controller_test.rb
+++ b/test/controllers/categories_controller_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class CategoriesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @category = categories(:one)
+  end
+
+  test "should get index" do
+    get categories_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_category_url
+    assert_response :success
+  end
+
+  test "should create category" do
+    assert_difference("Category.count") do
+      post categories_url, params: { category: { discussions_count: @category.discussions_count, name: @category.name } }
+    end
+
+    assert_redirected_to category_url(Category.last)
+  end
+
+  test "should show category" do
+    get category_url(@category)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_category_url(@category)
+    assert_response :success
+  end
+
+  test "should update category" do
+    patch category_url(@category), params: { category: { discussions_count: @category.discussions_count, name: @category.name } }
+    assert_redirected_to category_url(@category)
+  end
+
+  test "should destroy category" do
+    assert_difference("Category.count", -1) do
+      delete category_url(@category)
+    end
+
+    assert_redirected_to categories_url
+  end
+end

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  discussions_count: 1
+
+two:
+  name: MyString
+  discussions_count: 1

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CategoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/system/categories_test.rb
+++ b/test/system/categories_test.rb
@@ -1,0 +1,43 @@
+require "application_system_test_case"
+
+class CategoriesTest < ApplicationSystemTestCase
+  setup do
+    @category = categories(:one)
+  end
+
+  test "visiting the index" do
+    visit categories_url
+    assert_selector "h1", text: "Categories"
+  end
+
+  test "should create category" do
+    visit categories_url
+    click_on "New category"
+
+    fill_in "Discussions count", with: @category.discussions_count
+    fill_in "Name", with: @category.name
+    click_on "Create Category"
+
+    assert_text "Category was successfully created"
+    click_on "Back"
+  end
+
+  test "should update Category" do
+    visit category_url(@category)
+    click_on "Edit this category", match: :first
+
+    fill_in "Discussions count", with: @category.discussions_count
+    fill_in "Name", with: @category.name
+    click_on "Update Category"
+
+    assert_text "Category was successfully updated"
+    click_on "Back"
+  end
+
+  test "should destroy Category" do
+    visit category_url(@category)
+    click_on "Destroy this category", match: :first
+
+    assert_text "Category was successfully destroyed"
+  end
+end


### PR DESCRIPTION
A generated scaffold for Category has allowed a lot of the code in this application to prebuilt by the scaffold command.

The navbar has been updated with links to the Discussions and Categories indexes.

Categories has been associated with the discussion model, and when creating a new discussion it needs to be assigned a category, that the user can also create (categories) via the category index page.

Migrations have also been performed and integrated into the DB schema to bring in categories and a category ID being assigned to a specific discussion.

The discussion form has also added the new category collection select to it.