### PR TITLE
Categories Added to the Discussion Index

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -2,4 +2,8 @@ class Category < ApplicationRecord
   has_many :discussions, dependent: :nullify
 
   scope :sorted, -> { order(name: :asc ) }
+
+  after_create_commit -> { broadcast_prepend_to "categories" }
+  after_update_commit -> { broadcast_replace_to "categories" }
+  after_destroy_commit -> { broadcast_remove_to "categories" }
 end

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -2,6 +2,8 @@ class Discussion < ApplicationRecord
   belongs_to :user, default: -> { Current.user }
   belongs_to :category, counter_cache: true, touch: true
 
+  delegate :name, prefix: :category, to: :category, allow_nil: true
+
   validates :title, presence: true
 
   has_many :posts, dependent: :destroy

--- a/app/views/categories/_category.html.erb
+++ b/app/views/categories/_category.html.erb
@@ -1,12 +1,4 @@
-<div id="<%= dom_id category %>">
-  <p>
-    <strong>Name:</strong>
-    <%= category.name %>
-  </p>
-
-  <p>
-    <strong>Discussions count:</strong>
-    <%= category.discussions_count %>
-  </p>
-
+<div id="<%= dom_id(category) %>" class="d-flex align-items-start justify-content-between">
+  <h4><%= category.name %></h4>
+  <span class="badge bg-secondary rounded-pill text-light"><%= category.discussions_count if category.discussions_count&.positive? %></span>
 </div>

--- a/app/views/discussions/_discussion.html.erb
+++ b/app/views/discussions/_discussion.html.erb
@@ -1,5 +1,6 @@
 <div id="<%= dom_id(discussion) %>" class="mb-2">
   <h3><%= link_to discussion.title, discussion %></h3>
+    Posted in: <%= discussion.category_name %> | Posts: <%= discussion.posts_count %>
   <div>
     <%= link_to "Edit", edit_discussion_path(discussion) %>
     <%= link_to "Delete", discussion_path(discussion), data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to delete this discussion? This cannot be undone" } %>

--- a/app/views/discussions/index.html.erb
+++ b/app/views/discussions/index.html.erb
@@ -7,9 +7,18 @@
 
 
 <div class="row mt-4">
-  <div class="col">
-    <div id="discussions">
-      <%= render @discussions %>
+ <div class="col-3">
+    <%= turbo_stream_from 'categories' %>
+    <h3>Categories</h3>
+    <div id="categories">
+      <%= render(partial: "categories/category", collection: Category.sorted) %>
+    </div>
+  </div>
+
+    <div class="col">
+      <div id="discussions">
+        <%= render @discussions %>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Categories are now visible along with a count of the amount of discussions in each category in the dicussions index view page.

Turbo broadcasts have been implemented in the category model to display realtime changes to the user and others without refresh, on the discussion index page.

There is also a posts count in the discussion index displaying the amount of posts per discussion, a good way for users to see if there have been any new posts to a discussions without having to view the page to check.