### PR TITLE
Category Filtering Added to Discussions

### DIFF
--- a/app/controllers/categories/discussions_controller.rb
+++ b/app/controllers/categories/discussions_controller.rb
@@ -1,0 +1,17 @@
+module Categories
+  class DiscussionsController < ApplicationController
+    before_action :authenticate_user!
+    before_action :set_category
+
+    def index
+      @discussions = @category.discussions.order(updated_at: :desc)
+      render 'discussions/index'
+    end
+
+    private
+
+    def set_category
+      @category = Category.find(params[:id])
+    end
+  end
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -6,4 +6,8 @@ class Category < ApplicationRecord
   after_create_commit -> { broadcast_prepend_to "categories" }
   after_update_commit -> { broadcast_replace_to "categories" }
   after_destroy_commit -> { broadcast_remove_to "categories" }
+
+  def to_param
+    "#{id}-#{name.downcase.to_s[0...100]}".parameterize
+  end
 end

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -10,6 +10,8 @@ class Discussion < ApplicationRecord
 
   accepts_nested_attributes_for :posts
 
+  broadcasts_to :category, inserts_by: :prepend
+
   after_create_commit -> { broadcast_prepend_to "discussions" }
   after_update_commit -> { broadcast_replace_to "discussions" }
   after_destroy_commit -> { broadcast_remove_to "discussions" }

--- a/app/views/categories/_category.html.erb
+++ b/app/views/categories/_category.html.erb
@@ -1,4 +1,4 @@
 <div id="<%= dom_id(category) %>" class="d-flex align-items-start justify-content-between">
-  <h4><%= category.name %></h4>
+  <h4><%= link_to category.name, category_discussions_path(category) %></h4>
   <span class="badge bg-secondary rounded-pill text-light"><%= category.discussions_count if category.discussions_count&.positive? %></span>
 </div>

--- a/app/views/discussions/index.html.erb
+++ b/app/views/discussions/index.html.erb
@@ -1,4 +1,8 @@
-<%= turbo_stream_from 'discussions' %>
+<% if @category.present? %>
+  <%= turbo_stream_from @category %>
+<% else %>
+  <%= turbo_stream_from 'discussions' %>
+<% end %>
 
 <div class="d-flex justify-content-between align-items-center">
   <h1>Active Discussions</h1>
@@ -17,7 +21,7 @@
 
     <div class="col">
       <div id="discussions">
-        <%= render @discussions %>
+        <%= render partial: "discussions/discussion", collection: @discussions %>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,10 @@ Rails.application.routes.draw do
 
   resources :discussions do
     resources :posts, only: [:create, :show, :edit, :update, :destroy], module: :discussions
+
+    collection do
+      get 'category/:id', to: "categories/discussions#index", as: :category
+    end
   end
 
   mount MissionControl::Jobs::Engine, at: "/jobs"


### PR DESCRIPTION
Categories can now be filtered to just the discussions that they contain, and discussions created are added to their specific category chosen.

Categories can be selected from the discussions index and then display only the discussions created for that particular category.

The routes have also been updated to assign category ID's to the discussions index.