### PR TITLE
Discussions can be Closed to Prevent Further Posts

### DIFF
--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -53,6 +53,16 @@ class DiscussionsController < ApplicationController
           new_category.reload.broadcast_replace_to("categories")
         end
 
+        if @discussion.saved_change_to_closed?
+          @discussion.broadcast_action_to(
+            @discussion,
+            action: :replace,
+            target: "new_post_form",
+            partial: "discussions/posts/form",
+            locals: { post: @discussion.posts.new }
+          )
+        end
+
         format.html { redirect_to @discussion, notice: "This discussion has been updated." }
       else
         format.html { render :edit, status: :unprocessable_entity }
@@ -68,7 +78,7 @@ class DiscussionsController < ApplicationController
   private
 
   def discussion_params
-    params.require(:discussion).permit(:title, :category_id, posts_attributes: :content)
+    params.require(:discussion).permit(:title, :category_id, :closed, posts_attributes: :content)
   end
 
   def set_discussion

--- a/app/views/discussions/_discussion.html.erb
+++ b/app/views/discussions/_discussion.html.erb
@@ -1,5 +1,6 @@
 <div id="<%= dom_id(discussion) %>" class="mb-2">
   <h3><%= link_to discussion.title, discussion %></h3>
+    Closed: <%= discussion.closed %>
     Posted in: <%= discussion.category_name %> | Posts: <%= discussion.posts_count %>
   <div>
     <%= link_to "Edit", edit_discussion_path(discussion) %>

--- a/app/views/discussions/_discussion_header.html.erb
+++ b/app/views/discussions/_discussion_header.html.erb
@@ -3,6 +3,10 @@
     <div>
       <h2><%= discussion.title %></h2>
     </div>
+
+    <% if discussion.closed %>
+      <span class="badge rounded-pill text-danger">Closed</span>
+    <% end %>
     <div>
       <%= link_to "Edit", edit_discussion_path(discussion) %>
       <%= link_to "Delete", discussion_path(discussion), data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to delete this discussion? This cannot be undone" } %>

--- a/app/views/discussions/_form.html.erb
+++ b/app/views/discussions/_form.html.erb
@@ -7,9 +7,14 @@
     { include_blank: "Pick a category..."}, { autofocus: false, class: "form-control" } %>
   </div>
 
+  <div class="mb-2">
+    <%= f.label :closed, class: "form-label" %>
+    <%= f.check_box :closed %>
+  </div>
+
   <% if @discussion.new_record? %>
     <%= f.simple_fields_for :posts do |p| %>
-      <div class="mb-3">
+      <div class="mb-2">
         <%= p.rich_text_area :content, placeholder: "Talk football..." %>
       </div>
     <% end %>

--- a/app/views/discussions/posts/_form.html.erb
+++ b/app/views/discussions/posts/_form.html.erb
@@ -1,9 +1,15 @@
 <%= turbo_frame_tag "#{dom_id(post)}_form", target: "_top"  do %>
-  <%= simple_form_for([post.discussion, post]) do |f| %>
-    <%= f.error_notification %>
+  <% if post.discussion.closed? && post.new_record? %>
+    <div class="alert alert-secondary fw-bold" role="alert">
+      This discussion is currently locked and new posts cannot be posted.
+    </div>
+  <% else %>
+    <%= simple_form_for([post.discussion, post]) do |f| %>
+      <%= f.error_notification %>
 
-    <%= f.input :content, as: :rich_text_area, input_html: { placeholder: "Add your post", autofocus: true }, label: false %>
+      <%= f.input :content, as: :rich_text_area, input_html: { placeholder: "Add your post", autofocus: true }, label: false %>
 
-    <%= f.button :submit, class: "btn btn-primary" %>
+      <%= f.button :submit, class: "btn btn-primary" %>
+    <% end %>
   <% end %>
 <% end %>

--- a/db/migrate/20240726181603_add_closed_to_discussions.rb
+++ b/db/migrate/20240726181603_add_closed_to_discussions.rb
@@ -1,0 +1,5 @@
+class AddClosedToDiscussions < ActiveRecord::Migration[7.1]
+  def change
+    add_column :discussions, :closed, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_22_214917) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_26_181603) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -66,6 +66,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_22_214917) do
     t.datetime "updated_at", null: false
     t.integer "posts_count", default: 0
     t.bigint "category_id"
+    t.boolean "closed", default: false
     t.index ["user_id"], name: "index_discussions_on_user_id"
   end
 


### PR DESCRIPTION
Discussions can be closed when created and via the edit action to prevent additional posts from being created within them.

Added the closed column to the discussions table in the schema via a new migration.

The discussion form has been updated to allow the user to select whether or not the discussion is closed or not, this is not permanent and can be ticked and unticked at the user's desire.