### PR TITLE
Added Lazy Loading to the Posts Partial

### DIFF
--- a/app/views/discussions/posts/_post.html.erb
+++ b/app/views/discussions/posts/_post.html.erb
@@ -5,14 +5,24 @@
       <%= post.content %>
     </div>
 
-    <div class="card-footer">
-      <%= link_to "Edit", edit_discussion_post_path(post.discussion, post), data: { turbo_frame: dom_id(post) } %> |
-      <%= link_to "Delete", discussion_post_path(post.discussion, post),
-              data: {
-                turbo_method: :delete,
-                turbo_frame: dom_id(post),
-                turbo_confirm: "Are you sure you want to delete this post?"
-              } %>    </div>
-      </div>#
+    <% if action_name.nil? %>
+       <%= turbo_frame_tag "post_actions", src: discussion_post_path(post.discussion, post) do %>
+         <div class="card-footer">
+       <% end %>
+    <% else %>
+      <%= turbo_frame_tag "post_actions" do %>
+        <% if Current.user == post.user || Current.user.admin? %>
+          <div class="card-footer mt-2">
+            <%= link_to "Edit", edit_discussion_post_path(post.discussion, post), data: { turbo_frame: dom_id(post) } %> |
+            <%= link_to "Delete", discussion_post_path(post.discussion, post),
+                    data: {
+                      turbo_method: :delete,
+                      turbo_frame: dom_id(post),
+                      turbo_confirm: "Are you sure you want to delete this post?"
+                    } %>    </div>
+            </div>
+          <% end %>
+        <% end %>
+      <% end %>#
     </div>
 <% end %>

--- a/db/migrate/20240728133047_add_admin_to_users.rb
+++ b/db/migrate/20240728133047_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_26_181603) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_28_133047) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -224,6 +224,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_26_181603) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "admin", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
Using Turbo means it automatically fetches content and in the case of Turbo Frames, automatically fetches and replaces the frame too. With lazy loading implemented, posts are not automatically fetched with all of the post actions: Edit and Delete. Rather, they are only loaded when they are needed, which results in a Turbo Frame with a source URL being created. This frame will load its content from discussion_post_path(post.discussion, post) when it becomes visible or is otherwise triggered.

New admin column added via a migration to the user schema to allow the admin user to be usable.