### PR TITLE
Pagy Introduced to Discussions and Categories

### DIFF
--- a/app/controllers/categories/discussions_controller.rb
+++ b/app/controllers/categories/discussions_controller.rb
@@ -4,7 +4,7 @@ module Categories
     before_action :set_category
 
     def index
-      @discussions = @category.discussions.order(updated_at: :desc)
+      @pagy, @discussions = pagy(@category.discussions.order(updated_at: :desc))
       render 'discussions/index'
     end
 

--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -3,7 +3,7 @@ class DiscussionsController < ApplicationController
   before_action :set_discussion, only: [:show, :edit, :destroy, :update]
 
   def index
-    @discussions = Discussion.all.order(updated_at: :desc)
+    @pagy, @discussions = pagy(Discussion.includes(:category))
   end
 
   def show

--- a/app/views/discussions/index.html.erb
+++ b/app/views/discussions/index.html.erb
@@ -20,9 +20,17 @@
   </div>
 
     <div class="col">
-      <div id="discussions">
-        <%= render partial: "discussions/discussion", collection: @discussions %>
-      </div>
+      <% if @category %>
+        <h4>Viewing discussions in <%= @category.name %></h4>
+      <% end %>
+      <% if params[:page].blank? || params[:page].eql?('1') %>
+        <div id="discussions"></div>
+      <% end %>
+      <%= render partial: "discussions/discussion", collection: @discussions %>
+
+      <hr class="mb-4">
+
+      <%== pagy_bootstrap_nav(@pagy) %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
The Pagy gem has been added to the discussions and categories index pages via the index controller for each of them, this means on the frontend if there are categories and/or discussions present pagination will take effect and allow the user to choose between pages of records of discussions, either from all discussions or the discussions as part of a specific category.