### PR TITLE
Discussion Subscription Start of Setup

### DIFF
--- a/app/models/discussion_subscription.rb
+++ b/app/models/discussion_subscription.rb
@@ -1,0 +1,19 @@
+class DiscussionSubscription < ApplicationRecord
+  belongs_to :discussion
+  belongs_to :user
+
+  scope :optin, ->  { where(subscription_type: :optin)}
+  scope :optout, -> { where(subscription_type: :optout)}
+
+  validates :subscription_type, presence: true, inclusion: { in: %w(optin optout) }
+  validates :user_id, uniqueness: { scope: :discussion_id }
+
+  def toggle!
+    case subscription_type
+    when "optin"
+      update(subscription_type: "optout")
+    when "optout"
+      update(subscription_type: "optin")
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,5 @@ class User < ApplicationRecord
 
   has_many :discussions, dependent: :destroy
   has_many :posts, dependent: :destroy
+  has_many :discuussion_subscriptions, dependent: :destroy
 end

--- a/db/migrate/20240802173332_create_discussion_subscriptions.rb
+++ b/db/migrate/20240802173332_create_discussion_subscriptions.rb
@@ -1,0 +1,11 @@
+class CreateDiscussionSubscriptions < ActiveRecord::Migration[7.1]
+  def change
+    create_table :discussion_subscriptions do |t|
+      t.references :discussion, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.string :subscription_type
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_28_133047) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_02_173332) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -57,6 +57,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_28_133047) do
     t.integer "discussions_count"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "discussion_subscriptions", force: :cascade do |t|
+    t.bigint "discussion_id", null: false
+    t.bigint "user_id", null: false
+    t.string "subscription_type"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["discussion_id"], name: "index_discussion_subscriptions_on_discussion_id"
+    t.index ["user_id"], name: "index_discussion_subscriptions_on_user_id"
   end
 
   create_table "discussions", force: :cascade do |t|
@@ -231,6 +241,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_28_133047) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "discussion_subscriptions", "discussions"
+  add_foreign_key "discussion_subscriptions", "users"
   add_foreign_key "discussions", "users"
   add_foreign_key "likes", "posts"
   add_foreign_key "likes", "users"

--- a/test/fixtures/discussion_subscriptions.yml
+++ b/test/fixtures/discussion_subscriptions.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  discussion: one
+  user: one
+  subscription_type: MyString
+
+two:
+  discussion: two
+  user: two
+  subscription_type: MyString

--- a/test/models/discussion_subscription_test.rb
+++ b/test/models/discussion_subscription_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DiscussionSubscriptionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
New discussion_subscription model created for handling users being subscribed via "optin" and not subscribed via "optout" to specific discussions.

Via the Rails console, tested that a discussion_subscription can be assigned "optin" and via the new "toggle!" this converts it into "optout".