### PR TITLE
Updated the Subscription Toggle Method

### DIFF
--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -7,6 +7,14 @@ class Discussion < ApplicationRecord
   validates :title, presence: true
 
   has_many :posts, dependent: :destroy
+  has_many :users, through: :posts
+  has_many :discussion_subscriptions, dependent: :destroy
+  has_many :optin_subscribers, -> { where(discussion_subscriptions: { subscription_type: :optin }) },
+    through: :discussion_subscriptions,
+    source: :user
+  has_many :optout_subscribers, -> { where(discussion_subscriptions: { subscription_type: :optout }) },
+    through: :discussion_subscriptions,
+    source: :user
 
   accepts_nested_attributes_for :posts
 
@@ -18,5 +26,24 @@ class Discussion < ApplicationRecord
 
   def to_param
     "#{id}-#{title.downcase.to_s[0...100]}".parameterize
+  end
+
+  def subscribed_users
+    (users + optin_subscribers).uniq - optout_subscribers
+  end
+
+  def subscription_for(user)
+    return nil if user.nil?
+    discussion_subscriptions.find_by(user_id: user.id)
+  end
+
+  def toggle_subscription(user)
+    if subscription = subscription_for(user)
+      subscription.toggle!
+    elsif posts.where(user_id: user.id).any?
+      discussion_subscriptions.create(user: user, subscription_type: "optout")
+    else
+      discussion_subscriptions.create(user: user, subscription_type: "optin")
+    end
   end
 end


### PR DESCRIPTION
Subscription Toggle has been updated in the discussion model to handle the toggling between optin and optout of a subscription better.

Calls in the Rails console of toggle_subscription now toggle between optin and optout, per each call of the method on a user and discussion.