### PR TITLE
Users can now see if they are Subscribed or Unsubscribed to a Discussion

### DIFF
--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -46,4 +46,30 @@ class Discussion < ApplicationRecord
       discussion_subscriptions.create(user: user, subscription_type: "optin")
     end
   end
+
+  def subscribed?(user)
+    return false if user.nil?
+
+    if subscription = subscription_for(user)
+      subscription.subscription_type == "optin"
+    else
+      posts.where(user_id: user.id).any?
+    end
+  end
+
+  def subscribed_reason(user)
+    return "You're not receiving notifications from this thread, please subscribe to receive them" if user.nil?
+
+    if subscription = subscription_for(user)
+      if subscription.subscription_type == "optout"
+        "You're ignoring this thread."
+      elsif subscription.subscription_type == "optin"
+        "You're receiving notifications because you've subscribed to this football discussion."
+      end
+    elsif posts.where(user_id: user.id).any?
+      "You're receiving notifications because you've posted in this football discussion."
+    else
+      "You're not receiving notifications from this football discusssion"
+    end
+  end
 end

--- a/app/views/discussions/notifications/_status.html.erb
+++ b/app/views/discussions/notifications/_status.html.erb
@@ -1,0 +1,7 @@
+<h4>Notifications</h4>
+<p><%= discussion.subscribed_reason(user) %></p>
+<% if discussion.subscribed?(user) %>
+  <%= button_to "Unsubscribe", root_path, class: "btn btn-primary btn-sm" %>
+<% else %>
+  <%= button_to "Subscribe", root_path, class: "btn btn-primary btn-sm" %>
+<% end %>

--- a/app/views/discussions/show.html.erb
+++ b/app/views/discussions/show.html.erb
@@ -19,6 +19,10 @@
 
 <hr class="my-4">
 
+<%= turbo_frame_tag "discussion_notification_status" do %>
+  <%= render("discussions/notifications/status", discussion: @discussion, user: Current.user) %>
+<% end %>
+
 <div id="<%= dom_id(@new_post) %>">
   <%= render("discussions/posts/form", post: @new_post, redirect: @pagy.page != @pagy.last) %>
 </div>


### PR DESCRIPTION
Users are subscribed to discussions they create, while they are unsubscribed
 to discussions other users are created, this is by default and can be toggled
 at will now by the user.

 Similar for posts, users are subscribed to discussions they have posted in,
 while discussions they haven't posted a post in they're unsubscribed from.