### PR TITLE
Email Notifications Now Send on New Posts in Discussions

### DIFF
--- a/app/controllers/discussions/posts_controller.rb
+++ b/app/controllers/discussions/posts_controller.rb
@@ -30,6 +30,8 @@ module Discussions
 
       respond_to do |format|
         if @post.save
+          send_post_notification!(@post)
+
           @pagy, @posts = pagy(@discussion.posts.order(created_at: :desc), items: 5)
           format.html { redirect_to discussion_path(@discussion, page: @pagy.last), notice: "Post created" }
           format.turbo_stream
@@ -50,6 +52,11 @@ module Discussions
     end
 
     private
+
+    def send_post_notification!(post)
+      post_subscribers = post.discussion.subscribed_users - [post.user]
+      NewPostNotification.with(post: post).deliver_later(post_subscribers)
+    end
 
     def set_discussion
       @discussion = Discussion.find(params[:discussion_id])

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -3,11 +3,12 @@ class UserMailer < ApplicationMailer
   # Subject can be set in your I18n file at config/locales/en.yml
   # with the following lookup:
   #
-  #   en.user_mailer.new_post.subject
+  #   en.user_mailer.new_post_notification.subject
   #
-  def new_post
-    @greeting = "Hi"
+  def new_post_notification
+    @user = params[:recipient]
+    @post = params[:post]
 
-    mail to: params[:user].email
+    mail(to: @user.email, subject: "There's been a response post in #{@post.discussion.title}.")
   end
 end

--- a/app/notifications/new_post_notification.rb
+++ b/app/notifications/new_post_notification.rb
@@ -17,7 +17,7 @@ class NewPostNotification < Noticed::Base
 
   # Define helper methods to make rendering easier.
   def message
-    "New post in #{params[:post].discussion.name}"
+    "New post in #{params[:post].discussion.title}"
   end
 
   def url

--- a/app/views/user_mailer/new_post.html.erb
+++ b/app/views/user_mailer/new_post.html.erb
@@ -1,5 +1,0 @@
-<h1>User#new_post</h1>
-
-<p>
-  <%= @greeting %>, find me in app/views/user_mailer/new_post.html.erb
-</p>

--- a/app/views/user_mailer/new_post.text.erb
+++ b/app/views/user_mailer/new_post.text.erb
@@ -1,3 +1,0 @@
-User#new_post
-
-<%= @greeting %>, find me in app/views/user_mailer/new_post.text.erb

--- a/app/views/user_mailer/new_post_notification.html.erb
+++ b/app/views/user_mailer/new_post_notification.html.erb
@@ -1,0 +1,7 @@
+Hi <%= @user.email %>,
+
+<p>Just wanted to let you know, there's a new post in <strong><%= @post.discussion.title %></strong>.</p>
+
+<%= link_to "Click here to view it", discussion_url(@post.discussion) %>
+
+<p>Thanks!</p>

--- a/app/views/user_mailer/new_post_notification.text.erb
+++ b/app/views/user_mailer/new_post_notification.text.erb
@@ -1,0 +1,3 @@
+User#new_post_notification
+
+<%= @greeting %>, find me in app/views/user_mailer/new_post_notification.text.erb

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -1,9 +1,9 @@
 # Preview all emails at http://localhost:3000/rails/mailers/user_mailer
 class UserMailerPreview < ActionMailer::Preview
 
-  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/new_post
-  def new_post
-    UserMailer.new_post
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/new_post_notification
+  def new_post_notification
+    UserMailer.new_post_notification
   end
 
 end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -1,12 +1,12 @@
 require "test_helper"
 
 class UserMailerTest < ActionMailer::TestCase
-  # test "new_post" do
-  #   mail = UserMailer.new_post
-  #   assert_equal "New post", mail.subject
-  #   assert_equal ["to@example.org"], mail.to
-  #   assert_equal ["from@example.com"], mail.from
-  #   assert_match "Hi", mail.body.encoded
-  # end
+  test "new_post_notification" do
+    mail = UserMailer.new_post_notification
+    assert_equal "New post notification", mail.subject
+    assert_equal ["to@example.org"], mail.to
+    assert_equal ["from@example.com"], mail.from
+    assert_match "Hi", mail.body.encoded
+  end
 
 end


### PR DESCRIPTION
If a user is subscribed to a discussion and a new post is made in the post by another user, they are notified now also by email.

Also I had an issue relating to name instead of title in a line of code in the previous PR related to notifications, this has now been resolved and notifications appear in the notifications index page for a user dependent upon the activity in a discussion they are subscribed to, and links directly to the discussion where the new post has been made.