### PR TITLE
Authentication Enhanced before being able to Navigate

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,4 +1,5 @@
 class CategoriesController < ApplicationController
+  before_action :authenticate_user!
   before_action :set_category, only: %i[ show edit update destroy ]
 
   # GET /categories or /categories.json

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,14 @@ Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
 
   # Defines the root path route ("/")
-  root to: "pages#home"
+
+  unauthenticated do
+    root to: "pages#home", as: :unauthenticated_root
+  end
+
+  authenticated do
+    root to: "discussions#index"
+  end
 
   resources :discussions do
     resources :posts, only: [:create, :show, :edit, :update, :destroy], module: :discussions


### PR DESCRIPTION
Strengthened the authentication around what a non
authenticated user can do before logging in or first signing up.  This is to prevent a user from being able to navigate to the discussions page without being logged in.  This is a security enhancement.  The user will be redirected to the login page if they try to access the discussions page without being logged in.

In the categories controller I added the authenticate_user! method to the before_action. This is to ensure that only authenticated users can access the categories page.